### PR TITLE
Modify image file type conversion

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -120,7 +120,7 @@ function load_images_cootes(;count=-1)
     imgs = Array(Array{Float64, 3}, n_use)    
     for i=1:n_use
         img_rgb = imread(paths[i])
-        img_rgb = convert(Image{RGB{U8}}, img_rgb)  # ensure 3-channel RGB
+        img_rgb = convert(Image{RGB{Float64}}, img_rgb)  # ensure 3-channel RGB
         imgs[i] = convert(Array, separate(img_rgb))
     end    
     return imgs


### PR DESCRIPTION
Convert image from U8 type to Float64 to prevent error: `ERROR:`fit`has no method matching fit(::AAModel, ::Image{RGB{UfixedBase{Uint8,8}},2,Array{RGB{UfixedBase{Uint8,8}},2}}, ::Array{Float64,2}, ::Int64)`
